### PR TITLE
(SIMP-10736) Add pubkey ssh support for AD (#124)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Jul 15 2022 Mark Fitch <mark.fitch1@hotmail.com> - 7.4.1
+  - Fixed:
+    - Added missing parameters `ldap_user_extra_attrs` and
+      `ldap_user_ssh_public_key` to allow SSH keys to be fetched from AD
+
 * Wed Jun 22 2022 Yehuda Katz <ykatz@cs.umd.edu> - 7.4.1
 - Allow `krb5_server` to be optional as implemented in the template
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -373,8 +373,17 @@ Install the required packages for SSSD
 
 The following parameters are available in the `sssd::install` class:
 
+* [`install_client`](#install_client)
 * [`install_user_tools`](#install_user_tools)
 * [`package_ensure`](#package_ensure)
+
+##### <a name="install_client"></a>`install_client`
+
+Data type: `Boolean`
+
+If ``true``, install the ``sssd`` client
+
+Default value: ``true``
 
 ##### <a name="install_user_tools"></a>`install_user_tools`
 
@@ -1747,6 +1756,8 @@ The following parameters are available in the `sssd::provider::ad` defined type:
 * [`ldap_use_tokengroups`](#ldap_use_tokengroups)
 * [`ldap_group_objectsid`](#ldap_group_objectsid)
 * [`ldap_user_objectsid`](#ldap_user_objectsid)
+* [`ldap_user_extra_attrs`](#ldap_user_extra_attrs)
+* [`ldap_user_ssh_public_key`](#ldap_user_ssh_public_key)
 
 ##### <a name="ad_domain"></a>`ad_domain`
 
@@ -2158,6 +2169,26 @@ Data type: `Optional[String[1]]`
 
 Default value: ``undef``
 
+##### <a name="ldap_user_extra_attrs"></a>`ldap_user_extra_attrs`
+
+Data type: `Optional[String[1]]`
+
+Can be used to enable public key storage for ssh
+When used this way, set this param and param ldap_user_ssh_public_key
+to 'altSecurityIdentities'
+
+Default value: ``undef``
+
+##### <a name="ldap_user_ssh_public_key"></a>`ldap_user_ssh_public_key`
+
+Data type: `Optional[String[1]]`
+
+Can be used to enable public key storage for ssh
+When used this way, set this param and param ldap_user_extra_attrs
+to 'altSecurityIdentities'
+
+Default value: ``undef``
+
 ### <a name="sssdproviderfiles"></a>`sssd::provider::files`
 
 NOTE: This defined type has no effect on SSSD < 1.16.0
@@ -2516,9 +2547,11 @@ The name of the associated domain section in the configuration file.
 
 ##### <a name="krb5_server"></a>`krb5_server`
 
-Data type: `Simplib::Host`
+Data type: `Optional[Simplib::Host]`
 
 
+
+Default value: ``undef``
 
 ##### <a name="krb5_realm"></a>`krb5_realm`
 
@@ -2905,7 +2938,7 @@ Default value: ``true``
 
 ##### <a name="ldap_search_base"></a>`ldap_search_base`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 
 
@@ -2921,7 +2954,7 @@ Default value: `'rfc2307'`
 
 ##### <a name="ldap_default_bind_dn"></a>`ldap_default_bind_dn`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,8 @@
 # Install the required packages for SSSD
 #
+# @param install_client
+#   If ``true``, install the ``sssd`` client
+#
 # @param install_user_tools
 #   If ``true``, install the 'sssd-tools' package for administrative
 #   changes to the SSSD databases

--- a/manifests/provider/ad.pp
+++ b/manifests/provider/ad.pp
@@ -85,6 +85,14 @@
 # @param ldap_use_tokengroups
 # @param ldap_group_objectsid
 # @param ldap_user_objectsid
+# @param ldap_user_extra_attrs
+#   Can be used to enable public key storage for ssh
+#   When used this way, set this param and param ldap_user_ssh_public_key
+#   to 'altSecurityIdentities'
+# @param ldap_user_ssh_public_key
+#   Can be used to enable public key storage for ssh
+#   When used this way, set this param and param ldap_user_extra_attrs
+#   to 'altSecurityIdentities'
 #
 # @author https://github.com/simp/pupmod-simp-sssd/graphs/contributors
 #
@@ -139,6 +147,8 @@ define sssd::provider::ad (
   Boolean                                                    $ldap_use_tokengroups                     = true,
   Optional[String[1]]                                        $ldap_group_objectsid                     = undef,
   Optional[String[1]]                                        $ldap_user_objectsid                      = undef,
+  Optional[String[1]]                                        $ldap_user_extra_attrs                    = undef,
+  Optional[String[1]]                                        $ldap_user_ssh_public_key                 = undef,
 ) {
   sssd::config::entry { "puppet_provider_${name}_ad":
     content => template("${module_name}/provider/ad.erb")

--- a/spec/defines/provider/ad_spec.rb
+++ b/spec/defines/provider/ad_spec.rb
@@ -100,7 +100,9 @@ describe 'sssd::provider::ad' do
           :ldap_idmap_autorid_compat                => false,
           :ldap_idmap_helper_table_size             => 8,
           :ldap_group_objectsid                     => 'my_ldap_group_objectsid',
-          :ldap_user_objectsid                      => 'my_ldap_user_objectsid'
+          :ldap_user_objectsid                      => 'my_ldap_user_objectsid',
+          :ldap_user_extra_attrs                    => 'altSecurityIdentities',
+          :ldap_user_ssh_public_key                 => 'altSecurityIdentities'
         }}
 
         it do
@@ -155,6 +157,8 @@ describe 'sssd::provider::ad' do
             ldap_use_tokengroups = true
             ldap_group_objectsid = my_ldap_group_objectsid
             ldap_user_objectsid = my_ldap_user_objectsid
+            ldap_user_extra_attrs = altSecurityIdentities
+            ldap_user_ssh_public_key = altSecurityIdentities
             EXPECTED
 
           is_expected.to create_sssd__config__entry("puppet_provider_#{title}_ad").with_content(expected)

--- a/templates/provider/ad.erb
+++ b/templates/provider/ad.erb
@@ -150,3 +150,9 @@ ldap_group_objectsid = <%= @ldap_group_objectsid %>
 <% if @ldap_user_objectsid -%>
 ldap_user_objectsid = <%= @ldap_user_objectsid %>
 <% end -%>
+<% if @ldap_user_extra_attrs -%>
+ldap_user_extra_attrs = <%= @ldap_user_extra_attrs %>
+<% end -%>
+<% if @ldap_user_ssh_public_key -%>
+ldap_user_ssh_public_key = <%= @ldap_user_ssh_public_key %>
+<% end -%>


### PR DESCRIPTION
Allow public key logins over ssh for ActiveDirectory computers and accounts

SIMP-10736 #close

Co-authored-by: Mark Fitch <mark.j.fitch8.ctr@army.mil>
Co-authored-by: op-ct <chris.tessmer@onyxpoint.com>
Co-authored-by: Trevor Vaughan <trevor@sicura.us>